### PR TITLE
Fix critère 10.5 (sur l'assistant RGAA)

### DIFF
--- a/css/common/base.scss
+++ b/css/common/base.scss
@@ -21,6 +21,11 @@ body {
 	@include typi-base();
 	font-family: $font-body;
 	background: $color-white;
+	color: $color-black;
+}
+
+a {
+	color: $color-black;
 }
 
 ul,


### PR DESCRIPTION
Ajout d'une couleur de police pour les tests et instructions.

Auparavant : les textes prenaient la couleur définie par l'utilisateur dans le navigateur.

![image](https://user-images.githubusercontent.com/6073336/137992594-e9a98342-0a0f-48d2-ae04-e0e47dd7f840.png)


