### PR TITLE
feat: meilleurs affichages des listes emboîtées - fixes #41

### DIFF
--- a/css/helpers/components/rgaaExt-OutlineHelper.scss
+++ b/css/helpers/components/rgaaExt-OutlineHelper.scss
@@ -1,19 +1,41 @@
 /* stylelint-disable declaration-no-important */
+@mixin nested-list($elem,  $item) {
 
-
-
-.rgaaExt-OutlineHelper {
-	margin: 0.5em 0 !important;
-	padding: 0.2em !important;
-	outline: 1px $color-red solid !important;
-	box-shadow: 0 0 10px $color-red !important;
-
-	.rgaaExt-OutlineHelper {
-		outline: 2px $color-red dashed !important;
-		box-shadow: none !important;
-
-		.rgaaExt-OutlineHelper {
-			outline: 2px $color-red dotted !important;
+	#{$elem}.rgaaExt-OutlineHelper {
+		outline: solid 2px $color-red !important;
+		& >  #{$item}.rgaaExt-OutlineHelper {
+			outline: dashed 1px $color-red !important;
+			& > #{$elem}.rgaaExt-OutlineHelper {
+				outline: dashed 2px $color-blue !important;
+				& > #{$item}.rgaaExt-OutlineHelper {
+					outline: dotted 1px $color-blue !important;
+					& > #{$elem}.rgaaExt-OutlineHelper {
+						outline: dashed 2px $color-green !important;
+						& > #{$item}.rgaaExt-OutlineHelper {
+							outline: dotted 1px $color-green !important;
+						}
+					}
+				}
+			}
 		}
 	}
 }
+
+.rgaaExt-OutlineHelper {
+	outline: 2px $color-red solid !important;
+	box-shadow: 0 0 10px $color-red !important;
+	margin: 0.5em !important;
+	padding: 0.5em !important;
+
+	.rgaaExt-OutlineHelper {
+		outline: 2px $color-blue dashed !important;
+		box-shadow: none !important;
+
+		.rgaaExt-OutlineHelper {
+			outline: 2px $color-green dotted !important;
+		}
+	}
+}
+
+@include nested-list('ul', 'li');
+@include nested-list('[role="list"]', '[role="listitem"]')

--- a/data/helpers/4-2021.json
+++ b/data/helpers/4-2021.json
@@ -2820,7 +2820,7 @@
 		},
 		{
 			"helper": "outline",
-			"selector": "[role='list'], [role='list'] [role='listitem']"
+			"selector": "[role='list'], [role='list'] [role='listitem'],  .toto"
 		},
 		{
 			"helper": "showAttributes",

--- a/fixtures/tests-thematique-9-structuration.html
+++ b/fixtures/tests-thematique-9-structuration.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="fr" xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+
 <head>
 	<title>test thématique 9</title>
 </head>
+
 <body>
 	<a href="#main">Acces rapide au contenu</a>
 	<h2>Si la page commence par un titre de niveau 2 ?</h2>
@@ -12,11 +14,40 @@
 	</header>
 	<nav role="navigation">
 		<ol>
-			<li>list item</li>
-			<li>list item</li>
-			<li>list item</li>
+			<li>
+				items list
+				<ul>
+					<li>item</li>
+					<li>item</li>
+					<li>
+						nested items list
+						<ul>
+							<li>item</li>
+							<li>item</li>
+							<li>item</li>
+							<li>
+								<ul>
+									<li>item</li>
+									<li>item</li>
+									<li>item</li>
+									<li>item</li>
+								</ul>
+							</li>
+						</ul>
+					</li>
+					<li>item</li>
+				</ul>
+			</li>
+			<li>item</li>
+			<li>item</li>
+			<li>item</li>
 		</ol>
 	</nav>
+	<div class="toto">
+		<div class="toto">
+			<div class="toto">List item Test</div>
+		</div>
+	</div>
 	<a id="ancre-out"></a>
 	<main role="main" id="main">
 		<a id="ancre-in"></a>
@@ -33,15 +64,17 @@
 				<dl>
 					<dt>Firefox</dt>
 					<dd>Un navigateur Web libre, open-source, multi-plateforme
-					dévelopé par la Mozilla Corporation et des centaines de
-					volontaires.</dd>
+						dévelopé par la Mozilla Corporation et des centaines de
+						volontaires.</dd>
 				</dl>
 
 				<h4>Sed augue ipsum egestas</h4>
 
 				<q lang="en">Build a future where people live in harmony with nature.</q>
 				We hope they succeed.</p>
-				<h5>Sed augue ipsum egestas <a href="#" title="avec un lien contenant un abréviation : réduction du temps de travail ">avec un lien</a></h5>
+				<h5>Sed augue ipsum egestas <a href="#"
+						title="avec un lien contenant un abréviation : réduction du temps de travail ">avec un lien</a>
+				</h5>
 				<blockquote cite="http://www.la-grange.net/w3c/html4.01/struct/text.html#h-9.2.2">
 					<p>
 						L'élément BLOCKQUOTE indique une citation longue
@@ -72,6 +105,12 @@
 		<div role="list">
 			<div role="listitem">list item</div>
 			<div role="listitem">list item</div>
+			<div role="listitem">
+				<div role="list">
+					<div role="listitem">other list item</div>
+					<div role="listitem">other list item</div>
+				</div>
+			</div>
 			<div role="listitem">list item</div>
 		</div>
 	</footer>
@@ -103,15 +142,17 @@
 				<dl>
 					<dt>Firefox</dt>
 					<dd>Un navigateur Web libre, open-source, multi-plateforme
-					dévelopé par la Mozilla Corporation et des centaines de
-					volontaires.</dd>
+						dévelopé par la Mozilla Corporation et des centaines de
+						volontaires.</dd>
 				</dl>
 
 				<h4>Sed augue ipsum egestas</h4>
 
 				<q lang="en">Build a future where people live in harmony with nature.</q>
 				We hope they succeed.</p>
-				<h5>Sed augue ipsum egestas <a href="#" title="avec un lien contenant un abréviation : réduction du temps de travail ">avec un lien</a></h5>
+				<h5>Sed augue ipsum egestas <a href="#"
+						title="avec un lien contenant un abréviation : réduction du temps de travail ">avec un lien</a>
+				</h5>
 				<blockquote cite="http://www.la-grange.net/w3c/html4.01/struct/text.html#h-9.2.2">
 					<p>
 						L'élément BLOCKQUOTE indique une citation longue
@@ -149,4 +190,5 @@
 		</ul>
 	</footer>
 </body>
+
 </html>


### PR DESCRIPTION
Lors du test du critère 9.3, s'il y a des listes emboîtées ce n'est pas très lisible. #41

![156608954-f7c1513f-56a1-4238-85cb-b6030c7e3a21](https://user-images.githubusercontent.com/117817104/200805037-644b446a-3fbc-4e0e-9531-088a811ab2a3.png)

Modifications:
1. Ajouts des espaces (margin & padding) entre les listes imbriquées.
2. Modification de la couleur des bordures pour chaque listes imbriquées. 

![Capture d’écran du 2022-11-09 10-57-17](https://user-images.githubusercontent.com/117817104/200800107-50474d14-017c-4a9b-9da6-6ec1465ff203.png)




