### PR TITLE
Fix: validateur HTML W3C (HTML local) - fixes #47

### DIFF
--- a/pages/validateLocalPage.html
+++ b/pages/validateLocalPage.html
@@ -15,7 +15,7 @@
 		>
 			<input type="hidden" name="ss" value="1">
 			<input type="hidden" name="verbose" value="1">
-			<input type="text" name="fragment" value="" />
+			<textarea name="fragment" value="" ></textarea>
 		</form>
 		<p>Chargement…</p>
 

--- a/src/common/api/validateLocalPage.js
+++ b/src/common/api/validateLocalPage.js
@@ -26,11 +26,12 @@ export const validateLocalPage = (url) => {
 				if (status !== 'complete' || tabId !== tab.id) {
 					return;
 				}
-				const tabWindow = getWindowObject(tab.url, {
+				const tabUrl = tab?.pendingUrl || tab?.url;
+				const tabWindow = getWindowObject(tabUrl, {
 					type: 'tab',
 					windowId: tab.windowId
 				});
-				if (!tabWindow || !tabWindow.validateSource) {
+				if (!tabWindow || typeof tabWindow?.validateSource !== 'function') {
 					return;
 				}
 				tabWindow.validateSource(source);


### PR DESCRIPTION
### Cette PR corrige le problème du validateur HTML des pages hors-ligne #47

Avant le correctif le validateur n'envoyé pas le code HTML au validateur W3C et la page reste bloquée sur chargement.

![validator-blocked-in-loading](https://user-images.githubusercontent.com/117817104/201617348-6171de00-c8cc-49d7-9b5b-d977f96eabdb.png)

Après le correctif le code source HTML est soumit au validateur W3C et on est redirigé vers la page qui affiche le rapport de scanne.

J'ai également remplacé l'input de type texte par un textarea pour garder la mise en forme du code source d'origine et avoir une meilleurs lisibilité.

Avec un input de type texte:
![html-validator-no-formatted](https://user-images.githubusercontent.com/117817104/201619793-63b6a109-5307-4dc3-8d2f-66954542cac5.png)

Avec un textarea:
![html-validator-formatted](https://user-images.githubusercontent.com/117817104/201618375-e3771a11-b005-47ec-8ea3-71be93312d33.png)
