### PR TITLE
fix: #44 Corrige l'implémentation du test 6.1.4

### DIFF
--- a/data/helpers/4-2019.json
+++ b/data/helpers/4-2019.json
@@ -2522,22 +2522,24 @@
 		},
 		{
 			"helper": "outline",
-			"selector": "svg a"
+			"selector": "svg:has(a)"
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg a",
+			"selector": "svg:has(a)",
 			"showContent": true
 		},
 		{
-			"helper": "showAttributes",
-			"selector": "svg a",
+			"helper": "showChildElements",
+			"selector": "svg:has(a)",
+			"childrenSelector": "a",
 			"attributes": [
 				"aria-label",
 				"aria-labelledby",
 				"xlink:href",
 				"x-link:title"
-			]
+			],
+			"showContent": true
 		}
 	],
 	"6.2.1": [

--- a/data/helpers/4-2021.json
+++ b/data/helpers/4-2021.json
@@ -2498,22 +2498,24 @@
 		},
 		{
 			"helper": "outline",
-			"selector": "svg a"
+			"selector": "svg:has(a)"
 		},
 		{
 			"helper": "showElement",
-			"selector": "svg a",
+			"selector": "svg:has(a)",
 			"showContent": true
 		},
 		{
-			"helper": "showAttributes",
-			"selector": "svg a",
+			"helper": "showChildElements",
+			"selector": "svg:has(a)",
+			"childrenSelector": "a",
 			"attributes": [
 				"aria-label",
 				"aria-labelledby",
 				"xlink:href",
 				"x-link:title"
-			]
+			],
+			"showContent": true
 		}
 	],
 	"6.2.1": [


### PR DESCRIPTION
Le test 6.1.4 doit mettre en valeur les balises svg qui ont un lien. Actuellement on cible le lien ce qui ne fonctionne pas puisque les éléments HTML ajoutés par les helpers se positionnent en enfant du svg.
J'ai donc corrigé le sélecteur dans les helpers pour cibler les svg qui ont un lien grace au récent sélecteur :has (à noter que le support nécessite encore l'activation d'un flag sur firefox). Sélecteur déjà utilisé pour d'autres tests c'est pourquoi je me suis permis de l'utiliser.
J'ai aussi rajouté un helper pour remonter le contenu du lien enfant ainsi que certains de ces attributs.