### PR TITLE
Fix: Absence de couleur de texte par défaut pour les tests et instructions #46

### DIFF
--- a/css/panel/base.scss
+++ b/css/panel/base.scss
@@ -5,6 +5,7 @@ html,
 body {
 	height: 100%;
 	overflow: hidden;
+	color: $color-black;
 }
 
 button,


### PR DESCRIPTION
Cette PR fix le problème d'absence de couleur de texte par défaut pour les tests et les instructions #46 

Maintenant les paragraphes `<p>` et les listes `<li>` ont une couleur de texte par défaut.