### PR TITLE
Corrige l'implémentation du test 10.1.1 #27

### DIFF
--- a/data/helpers/4-2021.json
+++ b/data/helpers/4-2021.json
@@ -2889,7 +2889,7 @@
 		},
 		{
 			"helper": "outline",
-			"selector": "basefont, blink, center, font, marquee, s, strike, tt, u",
+			"selector": "basefont, blink, center, font, marquee, s, strike, tt, u, big",
 			"showTag":true
 		}
 	],


### PR DESCRIPTION
Le test est incomplet par rapport à sa description. En effet, l'élément <big> n'est pas mis en valeur. J'ai donc corrigé l'implémentation du test et y ai ajouté les balises big parmis la liste des tags à mettre en valeur lors de l'activation du test.