### PR TITLE
Fixed display name of version 4.1.2

### DIFF
--- a/data/references/4.1-2023.json
+++ b/data/references/4.1-2023.json
@@ -1,5 +1,5 @@
 {
-	"name": "RGAA 4.1 (2023)",
+	"name": "RGAA 4.1.2 (2023)",
 	"version": "4.1-2023",
 	"themes": [
 		{

--- a/src/common/api/reference.js
+++ b/src/common/api/reference.js
@@ -11,7 +11,7 @@ export const getReferencesList = () => [
 	{name: 'RGAA 3-2017', version: '3-2017'},
 	{name: 'RGAA 4.0 (2019)', version: '4-2019'},
 	{name: 'RGAA 4.1 (2021)', version: '4-2021'},
-	{name: 'RGAA 4.1 (2023)', version: '4.1-2023'}
+	{name: 'RGAA 4.1.2 (2023)', version: '4.1-2023'}
 ];
 
 /**


### PR DESCRIPTION
We should rethink version naming globally to keep things coherent, but it is out of scope for now.