### PR TITLE
Refactored styles toggle

### DIFF
--- a/src/common/actions/styles.js
+++ b/src/common/actions/styles.js
@@ -1,0 +1,30 @@
+/**
+ *
+ */
+export const TOGGLE = 'common/styles/TOGGLE';
+export const APPLY = 'common/styles/APPLY';
+export const REVERT = 'common/styles/REVERT';
+
+/**
+ *
+ */
+export const toggleStyles = (enabled) => ({
+	type: TOGGLE,
+	payload: enabled
+});
+
+/**
+ *
+ */
+export const applyStyles = () => ({
+	type: APPLY,
+	payload: {}
+});
+
+/**
+ *
+ */
+export const revertStyles = () => ({
+	type: REVERT,
+	payload: {}
+});

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -8,6 +8,7 @@ import tests from './tests';
 import instructions from './instructions';
 import checklist from './checklist';
 import imports from './imports';
+import styles from './styles';
 
 /**
  *	Reducers shared by each instance in the background.
@@ -27,7 +28,8 @@ export const appReducers = {
 	criteria,
 	tests,
 	checklist,
-	imports
+	imports,
+	styles
 };
 
 export const reducers = {

--- a/src/common/reducers/styles.js
+++ b/src/common/reducers/styles.js
@@ -1,0 +1,24 @@
+import {TOGGLE} from '../actions/styles';
+
+/**
+ *
+ */
+export const initialState = {
+	enabled: true
+};
+
+/**
+ *
+ */
+export default function styles(state = initialState, {type, payload}) {
+	switch (type) {
+		case TOGGLE:
+			return {
+				...state,
+				enabled: payload
+			};
+
+		default:
+			return state;
+	}
+}

--- a/src/common/sagas/panel.js
+++ b/src/common/sagas/panel.js
@@ -5,6 +5,7 @@ import {OPEN_POPUP, CLOSE_POPUP} from '../actions/runtime';
 import {applyAllHelpers, revertAllHelpers} from '../actions/helpers';
 import {SET_POSITION, OPEN, CLOSE} from '../actions/panel';
 import {Position} from '../api/panel';
+import {applyStyles, revertStyles} from '../actions/styles';
 
 /**
  *	Opens or closes a popup window depending on the dock position.
@@ -21,6 +22,7 @@ export function* setPositionWorker({payload: position}) {
  */
 export function* openWorker() {
 	yield put(applyAllHelpers());
+	yield put(applyStyles());
 }
 
 /**
@@ -28,6 +30,7 @@ export function* openWorker() {
  */
 export function* closeWorker() {
 	yield put(revertAllHelpers());
+	yield put(revertStyles());
 }
 
 /**

--- a/src/common/sagas/styles.js
+++ b/src/common/sagas/styles.js
@@ -1,0 +1,56 @@
+import {takeEvery} from 'redux-saga';
+import {call, put, select} from 'redux-saga/effects';
+import {applyHelpers, revertHelpers} from '../actions/helpers';
+import {APPLY, REVERT, TOGGLE} from '../actions/styles';
+import {areStylesEnabled} from '../selectors/styles';
+
+/**
+ *
+ */
+function* applyHelpersSaga(enabled) {
+	const effect = enabled ? revertHelpers : applyHelpers;
+	yield put(effect('styles', [{helper: 'disableAllStyles'}]));
+}
+
+/**
+ *
+ */
+function* toggleStylesSaga({payload: enabled}) {
+	yield call(applyHelpersSaga, enabled);
+}
+
+/**
+ *
+ */
+function* applyStylesSaga() {
+	const enabled = yield select(areStylesEnabled);
+	yield call(applyHelpersSaga, enabled);
+}
+
+/**
+ *
+ */
+function* revertStylesSaga() {
+	yield call(applyHelpersSaga, true);
+}
+
+/**
+ *
+ */
+export function* watchToggleStyles() {
+	yield* takeEvery(TOGGLE, toggleStylesSaga);
+}
+
+/**
+ *
+ */
+export function* watchApplyStyles() {
+	yield* takeEvery(APPLY, applyStylesSaga);
+}
+
+/**
+ *
+ */
+export function* watchRevertStyles() {
+	yield* takeEvery(REVERT, revertStylesSaga);
+}

--- a/src/common/selectors/styles.js
+++ b/src/common/selectors/styles.js
@@ -1,0 +1,6 @@
+import {property} from 'lodash';
+
+/**
+ *
+ */
+export const areStylesEnabled = property('styles.enabled');

--- a/src/panel/components/ReferencePage.js
+++ b/src/panel/components/ReferencePage.js
@@ -1,12 +1,11 @@
 import React, {Component, PropTypes} from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
 import renderIf from 'render-if';
 import {map, noop, debounce} from 'lodash';
 import {ThemeShape} from '../../common/types/theme';
 import ThemesListContainer from './ThemesListContainer';
 import DevToolsContainer from './DevToolsContainer';
 import ThemeContainer from './ThemeContainer';
-import Icon from './Icon';
+import StylesToggleContainer from './StylesToggleContainer';
 
 /**
  *
@@ -15,12 +14,7 @@ export default class ReferencePage extends Component {
 	constructor(props) {
 		super(props);
 		this.bindThemes = this.bindThemes.bind(this);
-		this.toggleStyles = this.toggleStyles.bind(this);
 		this.onScroll = debounce(this.props.onScroll, 500);
-
-		this.state = {
-			isCssDisabled: false
-		};
 	}
 
 	componentDidMount() {
@@ -47,17 +41,7 @@ export default class ReferencePage extends Component {
 		this.themesElement = domElement;
 	}
 
-	toggleStyles() {
-		this.props.toggleStyles(!this.state.isCssDisabled);
-		this.setState((state) => ({
-			...state,
-			isCssDisabled: !state.isCssDisabled
-		}));
-	}
-
 	render() {
-		const {isCssDisabled} = this.state;
-
 		return (
 			<div className="ReferencePage">
 				{renderIf(process.env.NODE_ENV !== 'production')(() => (
@@ -65,23 +49,7 @@ export default class ReferencePage extends Component {
 				))}
 				<div className="ReferencePage-actions">
 					<ThemesListContainer />
-					<button
-						className="ActionButton"
-						type="button"
-						onClick={this.toggleStyles}
-						title={this.props.intl.formatMessage({
-							id: `ReferencePage.styles.toggle.disabled.${
-								isCssDisabled ? 'true' : 'false'
-							}`
-						})}
-					>
-						{isCssDisabled ? (
-							<Icon name="visible" />
-						) : (
-							<Icon name="hidden" />
-						)}
-						<FormattedMessage id="ReferencePage.styles.toggle.label" />
-					</button>
+					<StylesToggleContainer />
 				</div>
 				<div ref={this.bindThemes} className="ReferencePage-themes">
 					{map(this.props.themes, (theme, n) => (
@@ -96,9 +64,7 @@ export default class ReferencePage extends Component {
 ReferencePage.propTypes = {
 	themes: PropTypes.arrayOf(ThemeShape).isRequired,
 	initialScrollPosition: PropTypes.number.isRequired,
-	onScroll: PropTypes.func,
-	toggleStyles: PropTypes.func.isRequired,
-	intl: intlShape.isRequired
+	onScroll: PropTypes.func
 };
 
 ReferencePage.defaultProps = {

--- a/src/panel/components/ReferencePageContainer.js
+++ b/src/panel/components/ReferencePageContainer.js
@@ -1,12 +1,10 @@
 import {connect} from 'react-redux';
 import {compose} from 'recompose';
 import {property, values} from 'lodash';
-import {injectIntl} from 'react-intl';
 import renderNothingUntil from '../../common/renderNothingUntil';
 import {saveScrollPosition} from '../../common/actions/themes';
 import {getScrollPosition} from '../../common/selectors/themes';
 import {isLoaded, getAllThemes} from '../../common/selectors/reference';
-import {applyHelpers, revertHelpers} from '../../common/actions/helpers';
 import ReferencePage from './ReferencePage';
 import deferRendering from './deferRendering';
 
@@ -25,13 +23,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
 	onScroll(event) {
 		dispatch(saveScrollPosition(event.target.scrollTop));
-	},
-	toggleStyles(isCssDisabled) {
-		if (isCssDisabled) {
-			dispatch(applyHelpers('global', [{helper: 'disableAllStyles'}]));
-		} else {
-			dispatch(revertHelpers('global', [{helper: 'disableAllStyles'}]));
-		}
 	}
 });
 
@@ -39,7 +30,6 @@ const mapDispatchToProps = (dispatch) => ({
  *
  */
 export default compose(
-	injectIntl,
 	connect(mapStateToProps, mapDispatchToProps),
 	renderNothingUntil(property('isReferenceLoaded'))
 	// I couln't figure out how to use deferRendering ala recompose HoCs

--- a/src/panel/components/StylesToggle.js
+++ b/src/panel/components/StylesToggle.js
@@ -1,0 +1,27 @@
+import React, {PropTypes} from 'react';
+import {FormattedMessage, intlShape} from 'react-intl';
+import Icon from './Icon';
+
+const StylesToggle = ({areStylesEnabled, toggleStyles, intl}) => (
+	<button
+		className="ActionButton"
+		type="button"
+		onClick={() => toggleStyles(!areStylesEnabled)}
+		title={intl.formatMessage({
+			id: `ReferencePage.styles.toggle.disabled.${
+				areStylesEnabled ? 'false' : 'true'
+			}`
+		})}
+	>
+		{areStylesEnabled ? <Icon name="visible" /> : <Icon name="hidden" />}
+		<FormattedMessage id="ReferencePage.styles.toggle.label" />
+	</button>
+);
+
+StylesToggle.propTypes = {
+	areStylesEnabled: PropTypes.bool.isRequired,
+	toggleStyles: PropTypes.func.isRequired,
+	intl: intlShape.isRequired
+};
+
+export default StylesToggle;

--- a/src/panel/components/StylesToggleContainer.js
+++ b/src/panel/components/StylesToggleContainer.js
@@ -1,0 +1,30 @@
+import {injectIntl} from 'react-intl';
+import {connect} from 'react-redux';
+import {compose} from 'recompose';
+import {areStylesEnabled} from '../../common/selectors/styles';
+import StylesToggle from './StylesToggle';
+import {toggleStyles} from '../../common/actions/styles';
+
+/**
+ *
+ */
+const mapStateToProps = (state) => ({
+	areStylesEnabled: areStylesEnabled(state)
+});
+
+/**
+ *
+ */
+const mapDispatchToProps = (dispatch) => ({
+	toggleStyles(enabled) {
+		dispatch(toggleStyles(enabled));
+	}
+});
+
+/**
+ *
+ */
+export default compose(
+	injectIntl,
+	connect(mapStateToProps, mapDispatchToProps)
+)(StylesToggle);

--- a/src/panel/sagas.js
+++ b/src/panel/sagas.js
@@ -2,6 +2,7 @@ import * as panel from '../common/sagas/panel';
 import * as imports from '../common/sagas/imports';
 import * as tests from '../common/sagas/tests';
 import * as criteria from '../common/sagas/criteria';
+import * as styles from '../common/sagas/styles';
 
 /**
  *
@@ -12,6 +13,9 @@ export default function* sagas() {
 		imports.watchApply(),
 		tests.watchEnable(),
 		tests.watchDisable(),
-		criteria.watchToggleCriterion()
+		criteria.watchToggleCriterion(),
+		styles.watchToggleStyles(),
+		styles.watchApplyStyles(),
+		styles.watchRevertStyles()
 	];
 }


### PR DESCRIPTION
We're using a dedicated reducer to store the feature's state, so we can properly handle the panel state (we want the styles to be reenabled when closing the panel).
We're also extracting the button into a separate component, to avoid polluting <ReferencePage />.