### PR TITLE
fix: Update deprecated MDN URLs to new URL structure

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,7 +1,7 @@
 # Architecture du code
 
 L'extension est basée sur le standard
-[WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions).
+[WebExtensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).
 
 Le `manifest.json` décrit la configuration de l'application et permet d'avoir
 une vue globale sur quelle partie du code est chargée où.

--- a/doc/installation-dev.md
+++ b/doc/installation-dev.md
@@ -9,5 +9,5 @@ npm start
 
 Chargez ensuite l'extension en suivant directement les docs officielles :
 
-- [Firefox Developer Edition](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
+- [Firefox Developer Edition](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
 - [Chrome 52 et plus](https://developer.chrome.com/extensions/getstarted#unpacked)

--- a/doc/publication.md
+++ b/doc/publication.md
@@ -20,4 +20,4 @@ npm run sign-extension -- --api-key CLE --api-secret SECRET
 
 Les paramètres `--api-key` et `--api-secret` renseignent les clés publiques et
 privées associées au compte qui publie l'extension (voir
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_sign).
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/web-ext_command_reference#web-ext_sign).


### PR DESCRIPTION
fix: Update deprecated MDN URLs to new URL structure

Mozilla restructured developer.mozilla.org paths. This PR updates deprecated MDN URLs to the new URL structure.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
